### PR TITLE
Add support for adding message tag to bubbles to allow sending messag…

### DIFF
--- a/restfbmessenger-core/src/main/java/com/github/marsbits/restfbmessenger/send/DefaultSendOperations.java
+++ b/restfbmessenger-core/src/main/java/com/github/marsbits/restfbmessenger/send/DefaultSendOperations.java
@@ -57,6 +57,7 @@ public class DefaultSendOperations implements SendOperations {
     public static final String MESSAGE_PARAM_NAME = "message";
     public static final String SENDER_ACTION_PARAM_NAME = "sender_action";
     public static final String NOTIFICATION_TYPE_PARAM_NAME = "notification_type";
+    public static final String TAG_PARAM_NAME = "tag";
 
     protected FacebookClient facebookClient;
 
@@ -79,7 +80,7 @@ public class DefaultSendOperations implements SendOperations {
             throws FacebookException {
         requireNonNull(recipient, "'recipient' must not be null");
         requireNonNull(senderAction, "'senderAction' must not be null");
-        return send(recipient, notificationType, Parameter.with(SENDER_ACTION_PARAM_NAME, senderAction.name()));
+        return send(recipient, notificationType, null, Parameter.with(SENDER_ACTION_PARAM_NAME, senderAction.name()));
     }
 
     @Override
@@ -114,29 +115,49 @@ public class DefaultSendOperations implements SendOperations {
 
     @Override
     public SendResponse message(MessageRecipient recipient, Message message) throws FacebookException {
-        return message(recipient, message, null);
+        return message(recipient, message, null, null);
     }
 
     @Override
-    public SendResponse message(MessageRecipient recipient, Message message, NotificationTypeEnum notificationType)
+    public SendResponse message(MessageRecipient recipient, Message message, MessageTagEnum tag) throws FacebookException {
+        return message(recipient, message, null, tag);
+    }
+
+    @Override
+    public SendResponse message(MessageRecipient recipient, Message message, NotificationTypeEnum notificationType, MessageTagEnum tag)
             throws FacebookException {
         requireNonNull(recipient, "'recipient' must not be null");
         requireNonNull(message, "'message' must not be null");
-        return send(recipient, notificationType, Parameter.with(MESSAGE_PARAM_NAME, message));
+        return send(recipient, notificationType, tag, Parameter.with(MESSAGE_PARAM_NAME, message));
+    }
+
+    @Override
+    public SendResponse message(MessageRecipient recipient, Message message, NotificationTypeEnum notificationType) throws FacebookException {
+        return message(recipient, message, notificationType, null);
     }
 
     @Override
     public SendResponse textMessage(MessageRecipient recipient, String text) throws FacebookException {
-        return textMessage(recipient, text, null);
+        return textMessage(recipient, text, null, null);
     }
 
     @Override
-    public SendResponse textMessage(MessageRecipient recipient, String text, NotificationTypeEnum notificationType)
+    public SendResponse textMessage(MessageRecipient recipient, String text, MessageTagEnum tag) throws FacebookException {
+        return textMessage(recipient, text, null, tag);
+    }
+
+    @Override
+    public SendResponse textMessage(MessageRecipient recipient, String text, NotificationTypeEnum notificationType, MessageTagEnum tag)
             throws FacebookException {
         requireNonNull(recipient, "'recipient' must not be null");
         requireNonNull(text, "'text' must not be null");
         Message message = new Message(text);
-        return message(recipient, message, notificationType);
+        return message(recipient, message, notificationType, tag);
+    }
+
+    @Override
+    public SendResponse textMessage(MessageRecipient recipient, String text, NotificationTypeEnum notificationType) throws FacebookException {
+        return textMessage(recipient, text, notificationType, null);
     }
 
     @Override
@@ -201,18 +222,29 @@ public class DefaultSendOperations implements SendOperations {
 
     @Override
     public SendResponse quickReplies(MessageRecipient recipient, String text, List<QuickReply> quickReplies) throws FacebookException {
-        return quickReplies(recipient, text, quickReplies, null);
+        return quickReplies(recipient, text, quickReplies, null, null);
     }
 
     @Override
     public SendResponse quickReplies(MessageRecipient recipient, String text, List<QuickReply> quickReplies,
-            NotificationTypeEnum notificationType) throws FacebookException {
+            NotificationTypeEnum notificationType, MessageTagEnum tag) throws FacebookException {
         requireNonNull(recipient, "'recipient' must not be null");
         requireNonNull(text, "'text' must not be null");
         requireNonNull(quickReplies, "'quickReplies' must not be null");
         Message message = new Message(text);
         message.addQuickReplies(quickReplies);
-        return message(recipient, message, notificationType);
+        return message(recipient, message, notificationType, tag);
+    }
+
+    @Override
+    public SendResponse quickReplies(MessageRecipient recipient, String text, List<QuickReply> quickReplies, MessageTagEnum tag) throws FacebookException {
+        return quickReplies(recipient, text, quickReplies, null, tag);
+    }
+
+    @Override
+    public SendResponse quickReplies(MessageRecipient recipient, String text, List<QuickReply> quickReplies,
+                                     NotificationTypeEnum notificationType) throws FacebookException {
+        return quickReplies(recipient, text, quickReplies, notificationType, null);
     }
 
     @Override
@@ -257,18 +289,28 @@ public class DefaultSendOperations implements SendOperations {
     @Override
     public SendResponse buttonTemplate(MessageRecipient recipient, ButtonTemplatePayload buttonTemplate,
             NotificationTypeEnum notificationType) throws FacebookException {
-        return template(recipient, buttonTemplate, notificationType);
+        return template(recipient, buttonTemplate, notificationType, null);
     }
 
     @Override
     public SendResponse genericTemplate(MessageRecipient recipient, GenericTemplatePayload genericTemplate) throws FacebookException {
-        return genericTemplate(recipient, genericTemplate, null);
+        return genericTemplate(recipient, genericTemplate, null, null);
+    }
+
+    @Override
+    public SendResponse genericTemplate(MessageRecipient recipient, GenericTemplatePayload genericTemplate, MessageTagEnum tag) throws FacebookException {
+        return genericTemplate(recipient, genericTemplate, null, tag);
     }
 
     @Override
     public SendResponse genericTemplate(MessageRecipient recipient, GenericTemplatePayload genericTemplate,
-            NotificationTypeEnum notificationType) throws FacebookException {
-        return template(recipient, genericTemplate, notificationType);
+            NotificationTypeEnum notificationType, MessageTagEnum tag) throws FacebookException {
+        return template(recipient, genericTemplate, notificationType, tag);
+    }
+
+    @Override
+    public SendResponse genericTemplate(MessageRecipient recipient, GenericTemplatePayload genericTemplate, NotificationTypeEnum notificationType) throws FacebookException {
+        return genericTemplate(recipient, genericTemplate, notificationType, null);
     }
 
     @Override
@@ -279,7 +321,7 @@ public class DefaultSendOperations implements SendOperations {
     @Override
     public SendResponse listTemplate(MessageRecipient recipient, ListTemplatePayload listTemplate, NotificationTypeEnum notificationType)
             throws FacebookException {
-        return template(recipient, listTemplate, notificationType);
+        return template(recipient, listTemplate, notificationType, null);
     }
 
     @Override
@@ -290,7 +332,7 @@ public class DefaultSendOperations implements SendOperations {
     @Override
     public SendResponse receiptTemplate(MessageRecipient recipient, ReceiptTemplatePayload receiptTemplate,
             NotificationTypeEnum notificationType) throws FacebookException {
-        return template(recipient, receiptTemplate, notificationType);
+        return template(recipient, receiptTemplate, notificationType, null);
     }
 
     @Override
@@ -302,7 +344,7 @@ public class DefaultSendOperations implements SendOperations {
     @Override
     public SendResponse airlineItineraryTemplate(MessageRecipient recipient, AirlineItineraryTemplatePayload airlineItineraryTemplate,
             NotificationTypeEnum notificationType) throws FacebookException {
-        return template(recipient, airlineItineraryTemplate, notificationType);
+        return template(recipient, airlineItineraryTemplate, notificationType, null);
     }
 
     @Override
@@ -314,7 +356,7 @@ public class DefaultSendOperations implements SendOperations {
     @Override
     public SendResponse airlineCheckinTemplate(MessageRecipient recipient, AirlineCheckinTemplatePayload airlineCheckinTemplate,
             NotificationTypeEnum notificationType) throws FacebookException {
-        return template(recipient, airlineCheckinTemplate, notificationType);
+        return template(recipient, airlineCheckinTemplate, notificationType, null);
     }
 
     @Override
@@ -327,7 +369,7 @@ public class DefaultSendOperations implements SendOperations {
     public SendResponse airlineBoardingPassTemplate(MessageRecipient recipient,
             AirlineBoardingPassTemplatePayload airlineBoardingPassTemplate, NotificationTypeEnum notificationType)
             throws FacebookException {
-        return template(recipient, airlineBoardingPassTemplate, notificationType);
+        return template(recipient, airlineBoardingPassTemplate, notificationType, null);
     }
 
     @Override
@@ -339,23 +381,26 @@ public class DefaultSendOperations implements SendOperations {
     @Override
     public SendResponse airlineUpdateTemplate(MessageRecipient recipient, AirlineUpdateTemplatePayload airlineUpdateTemplate,
             NotificationTypeEnum notificationType) throws FacebookException {
-        return template(recipient, airlineUpdateTemplate, notificationType);
+        return template(recipient, airlineUpdateTemplate, notificationType, null);
     }
 
-    protected SendResponse template(MessageRecipient recipient, TemplatePayload template, NotificationTypeEnum notificationType) {
+    protected SendResponse template(MessageRecipient recipient, TemplatePayload template, NotificationTypeEnum notificationType, MessageTagEnum tag) {
         requireNonNull(recipient, "'recipient' must not be null");
         requireNonNull(template, "'template' must not be null");
         TemplateAttachment attachment = new TemplateAttachment(template);
         Message message = new Message(attachment);
-        return message(recipient, message, notificationType);
+        return message(recipient, message, notificationType, tag);
     }
 
-    protected SendResponse send(MessageRecipient recipient, NotificationTypeEnum notificationType, Parameter... parameters) {
+    protected SendResponse send(MessageRecipient recipient, NotificationTypeEnum notificationType, MessageTagEnum tag, Parameter... parameters) {
         requireNonNull(recipient, "'recipient' must not be null");
         List<Parameter> params = new ArrayList<>();
         params.add(Parameter.with(RECIPIENT_PARAM_NAME, recipient));
         if (notificationType != null) {
             params.add(Parameter.with(NOTIFICATION_TYPE_PARAM_NAME, notificationType.name()));
+        }
+        if (tag != null) {
+            params.add(Parameter.with(TAG_PARAM_NAME, tag.name()));
         }
         params.addAll(Arrays.asList(parameters));
         return send(params.toArray(new Parameter[params.size()]));

--- a/restfbmessenger-core/src/main/java/com/github/marsbits/restfbmessenger/send/MessageTagEnum.java
+++ b/restfbmessenger-core/src/main/java/com/github/marsbits/restfbmessenger/send/MessageTagEnum.java
@@ -1,0 +1,9 @@
+package com.github.marsbits.restfbmessenger.send;
+
+/**
+ * Created by ronen on 4/9/17.
+ * Represents the available message tags https://developers.facebook.com/docs/messenger-platform/send-api-reference/tags
+ */
+public enum MessageTagEnum {
+    SHIPPING_UPDATE, RESERVATION_UPDATE, ISSUE_RESOLUTION
+}

--- a/restfbmessenger-core/src/main/java/com/github/marsbits/restfbmessenger/send/SendOperations.java
+++ b/restfbmessenger-core/src/main/java/com/github/marsbits/restfbmessenger/send/SendOperations.java
@@ -136,6 +136,17 @@ public interface SendOperations {
     /**
      * Sends the given message to the user.
      *
+     * @param recipient the recipient
+     * @param message   the message
+     * @param tag message tag
+     * @return the {@code SendResponse}
+     * @throws FacebookException in case an error occurs while performing the Facebook API call
+     */
+    SendResponse message(MessageRecipient recipient, Message message, MessageTagEnum tag) throws FacebookException;
+
+    /**
+     * Sends the given message to the user.
+     *
      * @param recipient        the recipient
      * @param message          the message
      * @param notificationType the push notification type
@@ -143,6 +154,18 @@ public interface SendOperations {
      * @throws FacebookException in case an error occurs while performing the Facebook API call
      */
     SendResponse message(MessageRecipient recipient, Message message, NotificationTypeEnum notificationType) throws FacebookException;
+
+    /**
+     * Sends the given message to the user.
+     *
+     * @param recipient        the recipient
+     * @param message          the message
+     * @param notificationType the push notification type
+     * @param tag message tag
+     * @return the {@code SendResponse}
+     * @throws FacebookException in case an error occurs while performing the Facebook API call
+     */
+    SendResponse message(MessageRecipient recipient, Message message, NotificationTypeEnum notificationType, MessageTagEnum tag) throws FacebookException;
 
     /**
      * Sends the given text message to the user.
@@ -157,6 +180,17 @@ public interface SendOperations {
     /**
      * Sends the given text message to the user.
      *
+     * @param recipient the recipient
+     * @param text      the text message
+     * @param tag message tag
+     * @return the {@code SendResponse}
+     * @throws FacebookException in case an error occurs while performing the Facebook API call
+     */
+    SendResponse textMessage(MessageRecipient recipient, String text, MessageTagEnum tag) throws FacebookException;
+
+    /**
+     * Sends the given text message to the user.
+     *
      * @param recipient        the recipient
      * @param text             the text message
      * @param notificationType the push notification type
@@ -164,6 +198,18 @@ public interface SendOperations {
      * @throws FacebookException in case an error occurs while performing the Facebook API call
      */
     SendResponse textMessage(MessageRecipient recipient, String text, NotificationTypeEnum notificationType) throws FacebookException;
+
+    /**
+     * Sends the given text message to the user.
+     *
+     * @param recipient        the recipient
+     * @param text             the text message
+     * @param notificationType the push notification type
+     * @param tag message tag
+     * @return the {@code SendResponse}
+     * @throws FacebookException in case an error occurs while performing the Facebook API call
+     */
+    SendResponse textMessage(MessageRecipient recipient, String text, NotificationTypeEnum notificationType, MessageTagEnum tag) throws FacebookException;
 
     /**
      * Sends the given attachment to the user.
@@ -298,6 +344,34 @@ public interface SendOperations {
             throws FacebookException;
 
     /**
+     * Sends the given text message and quick replies to the user.
+     *
+     * @param recipient        the recipient
+     * @param text             the text message
+     * @param quickReplies     the quick replies
+     * @param tag message tag
+     * @param notificationType the push notification type
+     * @return the {@code SendResponse}
+     * @throws FacebookException in case an error occurs while performing the Facebook API call
+     */
+    SendResponse quickReplies(MessageRecipient recipient, String text, List<QuickReply> quickReplies, NotificationTypeEnum notificationType, MessageTagEnum tag)
+            throws FacebookException;
+
+
+    /**
+     * Sends the given text message and quick replies to the user.
+     *
+     * @param recipient        the recipient
+     * @param text             the text message
+     * @param quickReplies     the quick replies
+     * @param tag message tag
+     * @return the {@code SendResponse}
+     * @throws FacebookException in case an error occurs while performing the Facebook API call
+     */
+    SendResponse quickReplies(MessageRecipient recipient, String text, List<QuickReply> quickReplies, MessageTagEnum tag)
+            throws FacebookException;
+
+    /**
      * Sends the given media attachment and quick replies to the user.
      *
      * @param recipient    the recipient
@@ -382,6 +456,17 @@ public interface SendOperations {
     /**
      * Sends the given generic template to the user.
      *
+     * @param recipient       the recipient
+     * @param genericTemplate the generic template
+     * @param tag the message tag
+     * @return the {@code SendResponse}
+     * @throws FacebookException in case an error occurs while performing the Facebook API call
+     */
+    SendResponse genericTemplate(MessageRecipient recipient, GenericTemplatePayload genericTemplate, MessageTagEnum tag) throws FacebookException;
+
+    /**
+     * Sends the given generic template to the user.
+     *
      * @param recipient        the recipient
      * @param genericTemplate  the generic template
      * @param notificationType the push notification type
@@ -389,6 +474,19 @@ public interface SendOperations {
      * @throws FacebookException in case an error occurs while performing the Facebook API call
      */
     SendResponse genericTemplate(MessageRecipient recipient, GenericTemplatePayload genericTemplate, NotificationTypeEnum notificationType)
+            throws FacebookException;
+
+    /**
+     * Sends the given generic template to the user.
+     *
+     * @param recipient        the recipient
+     * @param genericTemplate  the generic template
+     * @param notificationType the push notification type
+     * @param tag the message tag
+     * @return the {@code SendResponse}
+     * @throws FacebookException in case an error occurs while performing the Facebook API call
+     */
+    SendResponse genericTemplate(MessageRecipient recipient, GenericTemplatePayload genericTemplate, NotificationTypeEnum notificationType, MessageTagEnum tag)
             throws FacebookException;
 
     /**

--- a/restfbmessenger-core/src/test/java/com/github/marsbits/restfbmessenger/send/DefaultSendOperationsTests.java
+++ b/restfbmessenger-core/src/test/java/com/github/marsbits/restfbmessenger/send/DefaultSendOperationsTests.java
@@ -18,6 +18,7 @@ package com.github.marsbits.restfbmessenger.send;
 
 import com.restfb.FacebookClient;
 import com.restfb.Parameter;
+import com.restfb.types.MessageTag;
 import com.restfb.types.send.Bubble;
 import com.restfb.types.send.ButtonTemplatePayload;
 import com.restfb.types.send.CallButton;
@@ -57,11 +58,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
-import static com.github.marsbits.restfbmessenger.send.DefaultSendOperations.MESSAGES_PATH;
-import static com.github.marsbits.restfbmessenger.send.DefaultSendOperations.MESSAGE_PARAM_NAME;
-import static com.github.marsbits.restfbmessenger.send.DefaultSendOperations.NOTIFICATION_TYPE_PARAM_NAME;
-import static com.github.marsbits.restfbmessenger.send.DefaultSendOperations.RECIPIENT_PARAM_NAME;
-import static com.github.marsbits.restfbmessenger.send.DefaultSendOperations.SENDER_ACTION_PARAM_NAME;
+import static com.github.marsbits.restfbmessenger.send.DefaultSendOperations.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -168,6 +165,15 @@ public class DefaultSendOperationsTests {
     }
 
     @Test
+    public void testMessageWithTag() {
+        Message message = new Message("Hello!");
+        sendOperations.message(messageRecipient, message, MessageTagEnum.ISSUE_RESOLUTION);
+        verifySend(messageRecipient,
+                Parameter.with(TAG_PARAM_NAME, MessageTagEnum.ISSUE_RESOLUTION),
+                Parameter.with(MESSAGE_PARAM_NAME, message));
+    }
+
+    @Test
     public void testTextMessage() {
         String text = "Hello!";
         sendOperations.textMessage(messageRecipient, text);
@@ -182,6 +188,17 @@ public class DefaultSendOperationsTests {
         Message message = new Message(text);
         verifySend(messageRecipient,
                 Parameter.with(NOTIFICATION_TYPE_PARAM_NAME, NotificationTypeEnum.NO_PUSH),
+                Parameter.with(MESSAGE_PARAM_NAME, message));
+    }
+
+
+    @Test
+    public void testTextMessageWithTag() {
+        String text = "Hello!";
+        sendOperations.textMessage(messageRecipient, text, MessageTagEnum.RESERVATION_UPDATE);
+        Message message = new Message(text);
+        verifySend(messageRecipient,
+                Parameter.with(TAG_PARAM_NAME, MessageTagEnum.RESERVATION_UPDATE),
                 Parameter.with(MESSAGE_PARAM_NAME, message));
     }
 
@@ -309,6 +326,19 @@ public class DefaultSendOperationsTests {
                 Parameter.with(MESSAGE_PARAM_NAME, message));
     }
 
+
+    @Test
+    public void testQuickRepliesWithTextMessageAndTag() {
+        String text = "Hello!";
+        List<QuickReply> quickReplies = createQuickReplies();
+        sendOperations.quickReplies(messageRecipient, text, quickReplies, MessageTagEnum.SHIPPING_UPDATE);
+        Message message = new Message(text);
+        message.addQuickReplies(quickReplies);
+        verifySend(messageRecipient,
+                Parameter.with(TAG_PARAM_NAME, MessageTagEnum.SHIPPING_UPDATE),
+                Parameter.with(MESSAGE_PARAM_NAME, message));
+    }
+
     @Test
     public void testQuickRepliesWithMediaAttachment() {
         MediaAttachment attachment = createMediaAttachment();
@@ -392,6 +422,17 @@ public class DefaultSendOperationsTests {
         Message message = new Message(attachment);
         verifySend(messageRecipient,
                 Parameter.with(NOTIFICATION_TYPE_PARAM_NAME, NotificationTypeEnum.NO_PUSH),
+                Parameter.with(MESSAGE_PARAM_NAME, message));
+    }
+
+    @Test
+    public void testGenericTemplateWithTag() {
+        GenericTemplatePayload genericTemplate = createGenericTemplate();
+        sendOperations.genericTemplate(messageRecipient, genericTemplate, MessageTagEnum.RESERVATION_UPDATE);
+        TemplateAttachment attachment = new TemplateAttachment(genericTemplate);
+        Message message = new Message(attachment);
+        verifySend(messageRecipient,
+                Parameter.with(TAG_PARAM_NAME, MessageTagEnum.RESERVATION_UPDATE),
                 Parameter.with(MESSAGE_PARAM_NAME, message));
     }
 


### PR DESCRIPTION
…es outside of the 24h window

https://developers.facebook.com/docs/messenger-platform/send-api-reference/tags